### PR TITLE
Run-To-End Bug Fix

### DIFF
--- a/SMEZA_Adjuster/include/SMEZAMotorControl.h
+++ b/SMEZA_Adjuster/include/SMEZAMotorControl.h
@@ -12,7 +12,7 @@
 
 #define MTR_CTRL_DEBUG_FEEDBACK 0
 
-#define MILLIS_PER_STEP (uint16_t)100
+#define MILLIS_PER_STEP (uint32_t)100
 
 // Variables for incoming command storage 
 enum motor_direction
@@ -26,7 +26,7 @@ enum motor_direction
 extern uint8_t adjCommandRecievedFlag;
 extern uint8_t adjCommandAxis;
 extern motor_direction adjCommandDirection;
-extern uint16_t adjCommandNumSteps;
+extern uint32_t adjCommandNumSteps;
 
 extern SMEZAMotor xMotor;
 extern SMEZAMotor yMotor;

--- a/SMEZA_Adjuster/src/SMEZAMotorControl.cpp
+++ b/SMEZA_Adjuster/src/SMEZAMotorControl.cpp
@@ -9,7 +9,7 @@
 uint8_t adjCommandRecievedFlag = 0; 
 uint8_t adjCommandAxis = 0;
 motor_direction adjCommandDirection = motor_direction::noDirection;
-uint16_t adjCommandNumSteps = 0;
+uint32_t adjCommandNumSteps = 0;
 
 SMEZAMotor xMotor(POS_X_MOTOR_PIN, NEG_X_MOTOR_PIN, POS_X_LIMIT_PIN, NEG_X_LIMIT_PIN, 0);
 SMEZAMotor yMotor(POS_Y_MOTOR_PIN, NEG_Y_MOTOR_PIN, POS_Y_LIMIT_PIN, NEG_Y_LIMIT_PIN, 1);


### PR DESCRIPTION
Fixed a bug where the run-to-end command would stop after approx. 32 seconds. 

To fix this, I increased the size of adjCommandNumSteps from uint16 to uint32 